### PR TITLE
Add Webex bot skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # cxocoefeaturebot
+
+This project contains a simple Webex messaging bot written in Node.js. It listens for the `/new` command and creates a JIRA task for tracking feature requests.
+
+## Prerequisites
+
+- Node.js 16+
+- A Webex bot access token
+- Credentials for your JIRA instance
+
+## Setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Set the following environment variables:
+
+- `WEBEX_BOT_TOKEN` – token for your Webex bot
+- `JIRA_BASE_URL` – base URL of your JIRA instance, e.g. `https://your-domain.atlassian.net`
+- `JIRA_PROJECT_KEY` – key of the project where issues should be created
+- `JIRA_USER_EMAIL` – account email for API access
+- `JIRA_API_TOKEN` – API token for the account
+- `PORT` (optional) – port the bot listens on (default `3000`)
+
+Run the bot:
+
+```bash
+npm start
+```
+
+## Usage
+
+Send `/new <summary>` to your bot in Webex. The bot will create a new JIRA issue using the provided summary. The issue description will include the email address of the requester.
+
+Further JIRA fields can be customized in `index.js` inside `createJiraIssue`.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,75 @@
+const Framework = require('webex-node-bot-framework');
+const express = require('express');
+const fetch = require('node-fetch');
+
+const BOT_TOKEN = process.env.WEBEX_BOT_TOKEN;
+if (!BOT_TOKEN) {
+  console.error('WEBEX_BOT_TOKEN environment variable is required');
+  process.exit(1);
+}
+
+const framework = new Framework({ token: BOT_TOKEN });
+const app = express();
+
+framework.on('initialized', () => {
+  console.log('Framework initialized');
+});
+
+framework.hears('/new', (bot, trigger) => {
+  const summary = trigger.args.slice(1).join(' ') || 'New feature request';
+  createJiraIssue(summary, trigger.personEmail)
+    .then(issueKey => bot.say(`Created JIRA issue ${issueKey}`))
+    .catch(err => {
+      console.error('JIRA create error', err);
+      bot.say('Failed to create JIRA issue');
+    });
+});
+
+async function createJiraIssue(summary, reporter) {
+  const {
+    JIRA_BASE_URL,
+    JIRA_PROJECT_KEY,
+    JIRA_USER_EMAIL,
+    JIRA_API_TOKEN
+  } = process.env;
+
+  if (!JIRA_BASE_URL || !JIRA_PROJECT_KEY || !JIRA_USER_EMAIL || !JIRA_API_TOKEN) {
+    throw new Error('JIRA environment variables are not set');
+  }
+
+  const credentials = Buffer.from(`${JIRA_USER_EMAIL}:${JIRA_API_TOKEN}`).toString('base64');
+  const url = `${JIRA_BASE_URL}/rest/api/2/issue`;
+
+  const body = {
+    fields: {
+      project: { key: JIRA_PROJECT_KEY },
+      summary: summary,
+      description: `Feature request from ${reporter}`,
+      issuetype: { name: 'Task' }
+      // Additional fields can be provided here
+    }
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${credentials}`
+    },
+    body: JSON.stringify(body)
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  return data.key;
+}
+
+app.use('/', framework.webhook());
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  framework.start();
+  console.log(`Bot listening on port ${port}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cxocoefeaturebot",
+  "version": "0.1.0",
+  "description": "Webex bot to track feature requests via JIRA",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "webex-node-bot-framework": "^1.0.2",
+    "node-fetch": "^2.6.9"
+  }
+}


### PR DESCRIPTION
## Summary
- set up Node.js project
- implement basic Webex messaging bot that handles `/new` command
- add JIRA integration placeholder
- document environment variables and usage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b788aa9b4832b83a6e387a0cd3684